### PR TITLE
feat: 카드 연동 여부 추가

### DIFF
--- a/src/main/java/com/project/moneyj/analysis/controller/TransactionSummaryController.java
+++ b/src/main/java/com/project/moneyj/analysis/controller/TransactionSummaryController.java
@@ -1,12 +1,11 @@
 package com.project.moneyj.analysis.controller;
 
-import com.project.moneyj.analysis.dto.MonthlySummaryDTO;
 import com.project.moneyj.analysis.dto.MonthlySummaryDTO.CategorySummaryDTO;
+import com.project.moneyj.analysis.dto.SummaryResponseDTO;
 import com.project.moneyj.analysis.service.TransactionSummaryService;
 import com.project.moneyj.auth.dto.CustomOAuth2User;
 import com.project.moneyj.transaction.domain.TransactionCategory;
 import java.time.YearMonth;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,7 +21,7 @@ public class TransactionSummaryController {
     private final TransactionSummaryService transactionSummaryService;
 
     @GetMapping()
-    public ResponseEntity<List<MonthlySummaryDTO>> getRecent6MonthsSummary(
+    public ResponseEntity<SummaryResponseDTO> getRecent6MonthsSummary(
         @RequestParam(required = false) String base, // /summary?base=2025-09
         @AuthenticationPrincipal CustomOAuth2User customUser
     ) {

--- a/src/main/java/com/project/moneyj/analysis/dto/SummaryResponseDTO.java
+++ b/src/main/java/com/project/moneyj/analysis/dto/SummaryResponseDTO.java
@@ -1,0 +1,15 @@
+package com.project.moneyj.analysis.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SummaryResponseDTO {
+    private boolean cardConnected;
+    private List<MonthlySummaryDTO> monthly;
+
+    public static SummaryResponseDTO of(boolean cardConnected, List<MonthlySummaryDTO> monthly) {
+        return new SummaryResponseDTO(cardConnected, monthly);
+    }}

--- a/src/main/java/com/project/moneyj/analysis/service/TransactionSummaryService.java
+++ b/src/main/java/com/project/moneyj/analysis/service/TransactionSummaryService.java
@@ -4,6 +4,7 @@ package com.project.moneyj.analysis.service;
 import com.project.moneyj.analysis.domain.TransactionSummary;
 import com.project.moneyj.analysis.dto.MonthlySummaryDTO;
 import com.project.moneyj.analysis.dto.MonthlySummaryDTO.CategorySummaryDTO;
+import com.project.moneyj.analysis.dto.SummaryResponseDTO;
 import com.project.moneyj.analysis.repository.TransactionSummaryRepository;
 import com.project.moneyj.transaction.domain.Transaction;
 import com.project.moneyj.transaction.domain.TransactionCategory;
@@ -35,7 +36,18 @@ public class TransactionSummaryService {
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
-    public List<MonthlySummaryDTO> getRecent6MonthsSummary(Long userId, String baseYearMonth) {
+    public SummaryResponseDTO getRecent6MonthsSummary(Long userId, String baseYearMonth) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
+        boolean idCardConnected = user.isCardConnected();
+
+        // 6개월 요약 데이터 리스트를 조회
+        List<MonthlySummaryDTO> summaries = getMonthlySummary(userId, baseYearMonth);
+
+        return SummaryResponseDTO.of(idCardConnected, summaries);
+    }
+
+    private List<MonthlySummaryDTO> getMonthlySummary(Long userId, String baseYearMonth) {
         YearMonth base = YearMonth.parse(baseYearMonth);
         // 최근 6개월 리스트
         List<YearMonth> last6Months = IntStream.rangeClosed(0, 5)

--- a/src/main/java/com/project/moneyj/transaction/service/TransactionService.java
+++ b/src/main/java/com/project/moneyj/transaction/service/TransactionService.java
@@ -26,6 +26,10 @@ public class TransactionService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
 
+        if (!user.isCardConnected()) {
+            user.connectCard();
+        }
+
         Map<String, Object> response = codefCardService.getCardApprovalList(userId, req);
         List<Map<String, Object>> data = (List<Map<String, Object>>) response.get("data");
 

--- a/src/main/java/com/project/moneyj/user/domain/User.java
+++ b/src/main/java/com/project/moneyj/user/domain/User.java
@@ -44,6 +44,9 @@ public class User {
     @Column(nullable = false)
     private Role role;
 
+    @Column(nullable = false)
+    private boolean cardConnected = false;
+
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Transaction> transactionList = new ArrayList<>();
@@ -56,6 +59,10 @@ public class User {
         this.email = email;
         this.profileImage = profileImage;
         this.role = role;
+    }
+
+    public void connectCard() {
+        this.cardConnected = true;
     }
 
 }


### PR DESCRIPTION
## 🔗 반영 브랜치

(#이슈번호) 현재 브랜치 -> 반영 브랜치
(#) feature/... -> develop

## 📝 작업 내용
- 카드 연동 후 (커넥티드 발급 후) codef에서 카드 내역 가져와서 db에 저장할 때 유저의 connectedCard 필드를 true로 변경
- 월별 요약 조회시 응답에 카드 연동 여부 필드 추가

## 💬 리뷰 요구사항
