### PR TITLE
Refactor:  정적 팩토리 메서드 도입

### DIFF
--- a/src/main/java/com/project/moneyj/codef/domain/CodefConnectedId.java
+++ b/src/main/java/com/project/moneyj/codef/domain/CodefConnectedId.java
@@ -10,9 +10,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Entity
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Table(name = "codef_connected_id",
         indexes = {@Index(name="idx_user", columnList="user_id")},
         uniqueConstraints = {@UniqueConstraint(name="uk_connected_id", columnNames = "connected_id")})
@@ -35,6 +33,16 @@ public class CodefConnectedId {
     private LocalDateTime createdAt;
     @Column(name="updated_at")
     private LocalDateTime updatedAt;
+
+    private CodefConnectedId(Long userId, String connectedId, String status){
+        this.userId = userId;
+        this.connectedId = connectedId;
+        this.status = status;
+    }
+
+    public static CodefConnectedId of(Long userId, String connectedId, String status){
+        return CodefConnectedId.of(userId, connectedId, status);
+    }
 
     @PrePersist void prePersist() {
         if (createdAt == null) createdAt = LocalDateTime.now();

--- a/src/main/java/com/project/moneyj/codef/domain/CodefToken.java
+++ b/src/main/java/com/project/moneyj/codef/domain/CodefToken.java
@@ -11,8 +11,6 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "codef_token")
 public class CodefToken {
@@ -33,6 +31,15 @@ public class CodefToken {
     @PrePersist
     public void prePersist() {
         if (createdAt == null) createdAt = LocalDateTime.now();
+    }
+
+    private CodefToken(String accessToken, LocalDateTime expiresAt){
+        this.accessToken = accessToken;
+        this.expiresAt = expiresAt;
+    }
+
+    public static CodefToken of(String accessToken, LocalDateTime expiresAt){
+        return new CodefToken(accessToken, expiresAt);
     }
 
     // 비즈니스 메소드

--- a/src/main/java/com/project/moneyj/codef/service/CodefAccountService.java
+++ b/src/main/java/com/project/moneyj/codef/service/CodefAccountService.java
@@ -127,13 +127,7 @@ public class CodefAccountService {
         }
 
         // 4) DB 저장
-        connectedIdRepository.save(
-                CodefConnectedId.builder()
-                        .userId(userId)
-                        .connectedId(connectedId)
-                        .status("ACTIVE")
-                        .build()
-        );
+        connectedIdRepository.save(CodefConnectedId.of(userId, connectedId, "ACTIVE"));
 
         Map<String, Object> responseMap = parseCodefResponse(rawResponseBody);
         List<Map<String, Object>> successList = (List<Map<String, Object>>) ((Map<String, Object>) responseMap.get("data")).get("successList");

--- a/src/main/java/com/project/moneyj/codef/service/CodefAuthService.java
+++ b/src/main/java/com/project/moneyj/codef/service/CodefAuthService.java
@@ -49,10 +49,7 @@ public class CodefAuthService {
 
     private String issueFirst() {
         TokenResponseDTO res = requestAccessToken();
-        var newToken = CodefToken.builder()
-                .accessToken(res.getAccessToken())
-                .expiresAt(LocalDateTime.now().plusSeconds(res.getExpiresIn()))
-                .build();
+        var newToken = CodefToken.of(res.getAccessToken(), LocalDateTime.now().plusSeconds(res.getExpiresIn()));
         tokenRepository.save(newToken);
         return newToken.getAccessToken();
     }

--- a/src/main/java/com/project/moneyj/trip/domain/Category.java
+++ b/src/main/java/com/project/moneyj/trip/domain/Category.java
@@ -2,16 +2,13 @@ package com.project.moneyj.trip.domain;
 
 import com.project.moneyj.trip.dto.CategoryDTO;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "category")
 public class Category {
 

--- a/src/main/java/com/project/moneyj/trip/domain/TripPlan.java
+++ b/src/main/java/com/project/moneyj/trip/domain/TripPlan.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "trip_plan")
 public class TripPlan {
 

--- a/src/main/java/com/project/moneyj/trip/domain/TripSavingPhrase.java
+++ b/src/main/java/com/project/moneyj/trip/domain/TripSavingPhrase.java
@@ -5,10 +5,8 @@ import lombok.*;
 
 @Entity
 @Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 @Table(name = "trip_saving_phrase")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TripSavingPhrase {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -19,5 +17,13 @@ public class TripSavingPhrase {
     private TripMember tripMember;
 
     private String content;
+
+    private TripSavingPhrase(TripMember tripMember, String content){
+        this.tripMember = tripMember;
+        this.content = content;
+    }
+    public static TripSavingPhrase of(TripMember tripMember, String content){
+        return new TripSavingPhrase(tripMember, content);
+    }
 
 }

--- a/src/main/java/com/project/moneyj/trip/domain/TripTip.java
+++ b/src/main/java/com/project/moneyj/trip/domain/TripTip.java
@@ -6,9 +6,9 @@ import lombok.*;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Table(name = "trip_tip")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TripTip {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,4 +17,13 @@ public class TripTip {
     private String country;
 
     private String tip;
+
+    private TripTip(String country, String tip){
+        this.country = country;
+        this.tip = tip;
+    }
+
+    public static TripTip of(String country, String tip){
+        return new TripTip(country, tip);
+    }
 }

--- a/src/main/java/com/project/moneyj/trip/service/TripPlanService.java
+++ b/src/main/java/com/project/moneyj/trip/service/TripPlanService.java
@@ -449,10 +449,7 @@ public class TripPlanService {
                 .orElseThrow(() -> new IllegalArgumentException("TripMember가 없습니다."));
 
         for (String tip : response.getMessages()) {
-            TripSavingPhrase phrase = TripSavingPhrase.builder()
-                    .tripMember(tripMember)
-                    .content(tip)
-                    .build();
+            TripSavingPhrase phrase = TripSavingPhrase.of(tripMember, tip);
             tripSavingPhraseRepository.save(phrase);
         }
     }


### PR DESCRIPTION
## 🔗 반영 브랜치

(#54 ) refactor/domain -> develop

## 📝 작업 내용
<img width="992" height="268" alt="image" src="https://github.com/user-attachments/assets/49891700-ebd5-4cac-8fcc-a07d57b9146d" />

- 파라미터가 적은 도메인들 위주로 빌더 패턴 대신 정적 팩토리 메서드 패턴을 적용하였습니다.
- DTO 단위에서 사용하던 of()와 동일한 역할을 합니다. 
- 이로 인해 객체의 일관성과 불변성을 지키고, 무분별한 new 사용을 줄일 수 있습니다.

## 💬 이후 해야할 작업
- 현재 파라미터가 많고 복잡한 도메인은 리팩토링을 진행하지 않았습니다.
- 이러한 도메인은 빌더 패턴 + 정적 팩토리 메서드가 동시에 사용되어야할 것 같아 좀 더 학습한 후 진행하겠습니다.
- Account와 TripPlan의 연관관계를 다시 정의할  필요가 있어보입니다. 지금 바꾸기에는 DB에서 에러가 날 것 같아 건들지는 않았습니다.
