### PR TITLE
Hotfix: 목표 달성 API JSON 파싱 버그 해결

### DIFF
--- a/src/main/java/com/project/moneyj/trip/dto/isConsumedRequestDTO.java
+++ b/src/main/java/com/project/moneyj/trip/dto/isConsumedRequestDTO.java
@@ -1,6 +1,8 @@
 package com.project.moneyj.trip.dto;
 
 import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,5 +21,6 @@ public class isConsumedRequestDTO {
     private String categoryName;
 
     @NotNull
+    @JsonProperty("isConsumed")
     private boolean isConsumed;
 }

--- a/src/main/java/com/project/moneyj/trip/repository/CategoryRepository.java
+++ b/src/main/java/com/project/moneyj/trip/repository/CategoryRepository.java
@@ -24,7 +24,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     """)
     List<Category> findByTripPlanId(@Param("tripPlanId") Long tripPlanId);
 
-    @Query(value = "SELECT * FROM category WHERE category_name = :categoryName AND trip_member_id = :memberId", nativeQuery = true)
+    @Query("SELECT c FROM Category c WHERE c.categoryName = :categoryName AND c.tripMember.tripMemberId = :memberId")
     Optional<Category> findByCategoryNameAndMemberIdNative(@Param("categoryName") String categoryName, @Param("memberId") Long memberId);
 
 }


### PR DESCRIPTION
## 🔗 반영 브랜치

(#89 ) fix/trip-plan -> develop

## 📝 작업 내용

필드명이  isConsumed 같은 형식일 때, Lombok은 Getter를 getIsConsumed()가 아니라 isConsumed()로 만듬.
-> JSON이 파싱할 때, isConsumed이 아닌 consumed이란 필드명을 get 하게 됨.
-> 에러 발생

## 💬 리뷰 요구사항
로컬에서는 잘 파싱이 되어서 문제를 찾지 못하였는데, develop으로 합치고 나서 발견한 버그입니다. 
급하게 수정하여 PR 올립니다.